### PR TITLE
AdService Dockerfile

### DIFF
--- a/.github/workflows/image-cd.yaml
+++ b/.github/workflows/image-cd.yaml
@@ -29,6 +29,7 @@ jobs:
             SERVICES_JSON=$(echo "$SERVICES" | jq -R . | jq -sc .)
           fi
           
+          echo "====================================="
           echo "    Detected services: $SERVICES_JSON"
           echo "====================================="
           echo "services=$SERVICES_JSON" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/image-ci.yaml
+++ b/.github/workflows/image-ci.yaml
@@ -29,6 +29,7 @@ jobs:
             SERVICES_JSON=$(echo "$SERVICES" | jq -R . | jq -sc .)
           fi
           
+          echo "====================================="
           echo "    Detected services: $SERVICES_JSON"
           echo "====================================="
           echo "services=$SERVICES_JSON" >> "$GITHUB_OUTPUT"

--- a/microservices-demo/src/adservice/.dockerignore
+++ b/microservices-demo/src/adservice/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile*
+**/gradlew.bat
+README.md
+**/.gradle
+**/build

--- a/microservices-demo/src/adservice/Dockerfile
+++ b/microservices-demo/src/adservice/Dockerfile
@@ -3,13 +3,13 @@ FROM gradle:ubi-minimal AS build
 WORKDIR /app
 COPY . .
 
+RUN chmod +x gradlew
 RUN ./gradlew installDist --no-daemon
 RUN jdeps --ignore-missing-deps -q  \
     --recursive  \  
     --multi-release 17  \
     --print-module-deps  \
     /app/build/install/hipstershop/lib/*.jar > modules.txt
-
 RUN jlink \
     --add-modules $(cat modules.txt) \
     --strip-debug \

--- a/microservices-demo/src/adservice/Dockerfile
+++ b/microservices-demo/src/adservice/Dockerfile
@@ -5,19 +5,14 @@ COPY build.gradle genproto.sh gradlew settings.gradle /app/
 COPY gradle /app/gradle
 COPY src /app/src
 
-RUN ./gradlew installDist
-
-FROM eclipse-temurin:19.0.2_7-jre-focal@sha256:4f646d9ba7737e089a937d7a40427f8757f366829a03937b37112e2db5264b54 AS jre
-
-WORKDIR /app
-COPY --from=build /app/build/install/hipstershop /app/
+RUN ./gradlew installDist --no-daemon
 
 FROM alpine AS runtime
 
 RUN apk add --no-cache openjdk21-jre-headless
 
 WORKDIR /app
-COPY --from=jre /app /app/.
+COPY --from=build /app/build/install/hipstershop /app/
 
 RUN addgroup -g 1000 adservice && \
     adduser -u 1000 -G adservice -s /bin/sh -D adservice && \

--- a/microservices-demo/src/adservice/Dockerfile
+++ b/microservices-demo/src/adservice/Dockerfile
@@ -4,12 +4,28 @@ WORKDIR /app
 COPY . .
 
 RUN ./gradlew installDist --no-daemon
-RUN chmod +x /app/build/install/hipstershop/bin/AdService
+RUN jdeps --ignore-missing-deps -q  \
+    --recursive  \  
+    --multi-release 17  \
+    --print-module-deps  \
+    /app/build/install/hipstershop/lib/*.jar > modules.txt
 
-FROM eclipse-temurin:21-jre AS runtime
+RUN jlink \
+    --add-modules $(cat modules.txt) \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --output /min-app-jre
+
+FROM debian:bookworm-slim@sha256:b1a741487078b369e78119849663d7f1a5341ef2768798f7b7406c4240f86aef AS runtime
 
 WORKDIR /app
+
+COPY --from=build /min-app-jre /app/jre
 COPY --from=build /app/build/install/hipstershop /app
+
+ENV JAVA_HOME=/app/jre
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 EXPOSE 9555
 ENTRYPOINT ["/app/bin/AdService"]

--- a/microservices-demo/src/adservice/Dockerfile
+++ b/microservices-demo/src/adservice/Dockerfile
@@ -15,6 +15,7 @@ RUN jlink \
     --strip-debug \
     --no-man-pages \
     --no-header-files \
+    --compress 2 \
     --output /min-app-jre
 
 FROM debian:bookworm-slim@sha256:b1a741487078b369e78119849663d7f1a5341ef2768798f7b7406c4240f86aef AS runtime

--- a/microservices-demo/src/adservice/Dockerfile
+++ b/microservices-demo/src/adservice/Dockerfile
@@ -7,17 +7,10 @@ COPY src /app/src
 
 RUN ./gradlew installDist --no-daemon
 
-FROM alpine AS runtime
-
-RUN apk add --no-cache openjdk21-jre-headless
+FROM gcr.io/distroless/java21-debian12 AS runtime
 
 WORKDIR /app
-COPY --from=build /app/build/install/hipstershop /app/
+COPY --from=build /app/build/install/hipstershop /app
 
-RUN addgroup -g 1000 adservice && \
-    adduser -u 1000 -G adservice -s /bin/sh -D adservice && \
-    chown -R adservice:adservice /app
-
-USER adservice
 EXPOSE 9555
 ENTRYPOINT ["bin/AdService"]

--- a/microservices-demo/src/adservice/Dockerfile
+++ b/microservices-demo/src/adservice/Dockerfile
@@ -1,0 +1,28 @@
+FROM gradle:ubi-minimal AS build
+
+WORKDIR /app
+COPY build.gradle genproto.sh gradlew settings.gradle /app/
+COPY gradle /app/gradle
+COPY src /app/src
+
+RUN ./gradlew installDist
+
+FROM eclipse-temurin:19.0.2_7-jre-focal@sha256:4f646d9ba7737e089a937d7a40427f8757f366829a03937b37112e2db5264b54 AS jre
+
+WORKDIR /app
+COPY --from=build /app/build/install/hipstershop /app/
+
+FROM alpine AS runtime
+
+RUN apk add --no-cache openjdk21-jre-headless
+
+WORKDIR /app
+COPY --from=jre /app /app/.
+
+RUN addgroup -g 1000 adservice && \
+    adduser -u 1000 -G adservice -s /bin/sh -D adservice && \
+    chown -R adservice:adservice /app
+
+USER adservice
+EXPOSE 9555
+ENTRYPOINT ["bin/AdService"]

--- a/microservices-demo/src/adservice/Dockerfile
+++ b/microservices-demo/src/adservice/Dockerfile
@@ -1,16 +1,15 @@
 FROM gradle:ubi-minimal AS build
 
 WORKDIR /app
-COPY build.gradle genproto.sh gradlew settings.gradle /app/
-COPY gradle /app/gradle
-COPY src /app/src
+COPY . .
 
 RUN ./gradlew installDist --no-daemon
+RUN chmod +x /app/build/install/hipstershop/bin/AdService
 
-FROM gcr.io/distroless/java21-debian12 AS runtime
+FROM eclipse-temurin:21-jre AS runtime
 
 WORKDIR /app
 COPY --from=build /app/build/install/hipstershop /app
 
 EXPOSE 9555
-ENTRYPOINT ["bin/AdService"]
+ENTRYPOINT ["/app/bin/AdService"]


### PR DESCRIPTION
Created smallest possible image without future maintenance overhead.

Used jlink and jdeps at its final form to minimize size. Runtime is based on debian slim. 157MB in total uncompressed.
